### PR TITLE
Update st2136-1a-202x.xsd

### DIFF
--- a/st2136-1a-202x.xsd
+++ b/st2136-1a-202x.xsd
@@ -332,7 +332,7 @@
   </xs:complexContent>
 </xs:complexType>
 <xs:complexType name="ExponentParamsType">
-  <xs:attribute name="exponent" type="xs:float" use="required" default="1.0"/>
+  <xs:attribute name="exponent" type="xs:float" use="required"/>
   <xs:attribute name="offset" use="optional">
     <xs:simpleType>
       <xs:restriction base="xs:float">


### PR DESCRIPTION
Changing 
```<xs:attribute name="exponent" type="xs:float" use="required" default="1.0"/>```
back to
```<xs:attribute name="exponent" type="xs:float" use="required"/>``` (a required attribute cannot have a default value)